### PR TITLE
Proposal: avoid to override provided options

### DIFF
--- a/src/backbone.supermodel.js
+++ b/src/backbone.supermodel.js
@@ -168,9 +168,7 @@ Backbone.SuperModel = (function(_, Backbone){
           if (path.length == 1) {
             obj.attributes[finalPath] = value;
           } else {
-            options.skipNested = true;
-            options.forceChange = true;
-            obj.set(finalPath, value, options);
+            obj.set(finalPath, value, _.extend({skipNested: true, forceChange: true}, options));
           }
         }
       }


### PR DESCRIPTION
Overriding providing options conflict with backbone.stickit which keeps an options object per model. If overriding options is only necessary for recursive purpose, _.extend seems enough to make the job. Don't you think?
